### PR TITLE
Move custom nginx config to a different file

### DIFF
--- a/etc/conf.d/custom.conf
+++ b/etc/conf.d/custom.conf
@@ -1,0 +1,12 @@
+location = /api/session {
+  # Ensure we get traffic from an ELB that listens over HTTPS
+  if ($http_x_forwarded_proto != 'https') {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
+
+  # Bypass auth0 for this path
+  proxy_set_header "X-Forwarded-Proto" "https";
+  proxy_set_header "X-Forwarded-Port" "443";
+  # proxy_set_header "Host" "";
+  proxy_pass  http://127.0.0.1:5000/api/session;
+}

--- a/etc/conf.d/proxy_auth_bypass.conf
+++ b/etc/conf.d/proxy_auth_bypass.conf
@@ -1,3 +1,4 @@
+# WARNING: This is the location to bypass the authentication for.
 location = /api/session {
   # Ensure we get traffic from an ELB that listens over HTTPS
   if ($http_x_forwarded_proto != 'https') {

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -19,22 +19,11 @@ server {
   set $session_cookie_samesite off;
   set_by_lua_block $backend { return os.getenv("backend") }
 
+  include conf.d/custom.conf;
+
   location = /health {
     return 200;
     access_log off;
-  }
-
-  location = /api/session {
-    # Ensure we get traffic from an ELB that listens over HTTPS
-    if ($http_x_forwarded_proto != 'https') {
-      rewrite ^ https://$host$request_uri? permanent;
-    }
-
-    # Bypass auth0 for this path
-    proxy_set_header "X-Forwarded-Proto" "https";
-    proxy_set_header "X-Forwarded-Port" "443";
-    # proxy_set_header "Host" "";
-    proxy_pass  http://127.0.0.1:5000/api/session;
   }
 
   location / {

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -19,13 +19,15 @@ server {
   set $session_cookie_samesite off;
   set_by_lua_block $backend { return os.getenv("backend") }
 
-  include conf.d/custom.conf;
+  # Bypass authentication for certain locations (DANGEROUS!)
+  # include conf.d/proxy_auth_bypass.conf;
 
   location = /health {
     return 200;
     access_log off;
   }
 
+  # Default location, will enforce authentication there
   location / {
     # Ensure we get traffic from an ELB that listens over HTTPS
     if ($http_x_forwarded_proto != 'https') {


### PR DESCRIPTION
Moving it to a different file allows us to add/mount our own custom configuration.