### PR TITLE
Add extra proxy headers

### DIFF
--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -5,7 +5,6 @@ server {
   listen       80;
   root         /dev/null;
   error_page   500 502 503 504  /50x.html;
-  index        index.html ;
   location = /50x.html {
     root       /usr/local/openresty/nginx/html/;
   }
@@ -36,7 +35,9 @@ server {
 
     proxy_set_header "X-Forwarded-Proto" "https";
     proxy_set_header "X-Forwarded-Port" "443";
-    # proxy_set_header "Host" "";
+    proxy_set_header "X-Forwarded-For" $proxy_add_x_forwarded_for;
+    proxy_set_header "X-Real-IP" $remote_addr;
+    proxy_set_header "Host" $host;
     access_by_lua_file "/usr/local/openresty/nginx/conf/conf.d/openidc_layer.lua";
     proxy_pass $backend;
   }


### PR DESCRIPTION
We can put these in a separate file, but I think they'd be needed in 99% of use-cases.

Removing `index` just means it won't search for any static files.