### PR TITLE
Fix issue with non-existing claim for groups

### DIFF
--- a/etc/conf.d/openidc_layer.lua
+++ b/etc/conf.d/openidc_layer.lua
@@ -47,7 +47,7 @@ local gprs = ""
 local usergrp = ""
 if session.data.user.groups then
     usergrp = session.data.user.groups
-else
+elseif session.data.user['https://sso.mozilla.com/claim/groups'] then
     usergrp = session.data.user['https://sso.mozilla.com/claim/groups']
 end
 for k,v in pairs(usergrp) do


### PR DESCRIPTION
Only update usergrp with the claim if the claim actually exists
If not, it should stay empty