### PR TITLE
Don't iterate over groups if claims don't exist

### DIFF
--- a/etc/conf.d/openidc_layer.lua
+++ b/etc/conf.d/openidc_layer.lua
@@ -50,8 +50,10 @@ if session.data.user.groups then
 elseif session.data.user['https://sso.mozilla.com/claim/groups'] then
     usergrp = session.data.user['https://sso.mozilla.com/claim/groups']
 end
-for k,v in pairs(usergrp) do
-  grps = grps and grps.."|"..v or v
+if not usergrp == "" or not usergrp == nil then
+    for k,v in pairs(usergrp) do
+      grps = grps and grps.."|"..v or v
+    end
 end
 ngx.req.set_header("X-Forwarded-Groups", grps)
 


### PR DESCRIPTION
This was the issue we're running into. When logging in with anything but LDAP, neither group claim is sent, which caused this loop to fail.