### PR TITLE
Fix bug with X-Forwarded-Groups containing a leading pipe character

### DIFF
--- a/etc/conf.d/openidc_layer.lua
+++ b/etc/conf.d/openidc_layer.lua
@@ -43,7 +43,7 @@ ngx.req.set_header("OIDC_CLAIM_ID_TOKEN", session.data.enc_id_token)
 ngx.req.set_header("via",session.data.user.email)
 
 -- Flatten groups for apps that won't read JSON
-local grps = ""
+local grps = false
 local usergrp = ""
 if session.data.user.groups then
     usergrp = session.data.user.groups
@@ -52,7 +52,7 @@ elseif session.data.user['https://sso.mozilla.com/claim/groups'] then
 end
 if not usergrp == "" or not usergrp == nil then
     for k,v in pairs(usergrp) do
-      grps = grps and grps.."|"..v or v
+      grps = (grps and grps.."|"..v) or v  -- If grps is false, set grps to v, otherwise append "|v" to grps
     end
 end
 ngx.req.set_header("X-Forwarded-Groups", grps)


### PR DESCRIPTION
Fixes #20 

This fixes the bug, adds parentheses to clarify what's going on from a precedence standpoint and adds a comment to explain what the line is doing