### PR TITLE
Remove reference to deleted ACM cert

### DIFF
--- a/cloudformation/parameters.json
+++ b/cloudformation/parameters.json
@@ -11,7 +11,7 @@
     },
     {
         "ParameterKey": "CertificateARN",
-        "ParameterValue": "arn:aws:acm:us-west-2:656532927350:certificate/93b81548-c28d-4912-b621-fc6cc6b52274",
+        "ParameterValue": "ACM Certificat ARN goes here",
         "UsePreviousValue": false
     },
     {


### PR DESCRIPTION
This may help down the road to make it clear that using this parameters.json won't work without adding an ACM cert ARN