### PR TITLE
Improvements and fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,44 @@
 FROM centos:latest
 MAINTAINER kang <kang@insecure.ws>
 
-# Update image & basic dev tools
-RUN yum update -y && \
-    yum install -y sudo && \
-    yum install -y epel-release && \
-    yum groupinstall -y 'Development Tools'
+# Load package keys, add repos, install support packages, install openresty, lua-resty-openidc and credstash
+RUN gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+    rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+    rpmkeys --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 && \
+    rpm -qi gpg-pubkey-352c64e5 | $gpg | grep 0x6A2FAEA2352C64E5 && \
+    rpmkeys --import https://openresty.org/package/pubkey.gpg && \
+    rpm -qi gpg-pubkey-d5edeb74 | $gpg | grep 0x97DB7443D5EDEB74 && \
+    yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo && \
+    yum update -y && \
+    yum install -y --setopt=tsflags=nodocs openresty-opm openresty openresty-resty&& \
+    opm get zmartzone/lua-resty-openidc && \
+    yum erase -y openresty-opm && \
+    yum install -y --setopt=tsflags=nodocs epel-release && \
+    yum install -y --setopt=tsflags=nodocs python-pip && \
+    pip install credstash && \
+    yum erase -y python-pip && \
+    mkdir -v /usr/local/openresty/nginx/conf/ssl && \
+    openssl_cnf_filename=`mktemp` && \
+    printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" > $openssl_cnf_filename && \
+    /usr/local/openresty/openssl/bin/openssl req -x509 -out /usr/local/openresty/nginx/conf/ssl/localhost.crt \
+      -keyout /usr/local/openresty/nginx/conf/ssl/localhost.key \
+      -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -extensions EXT -config $openssl_cnf_filename
 
-# Install access-proxy-specific packages
-RUN yum install -y luarocks openssl-devel lua-devel yum-utils
+#     yum install -y --setopt=tsflags=nodocs sudo openssl-devel lua-devel yum-utils && \
 
-# Install things from luarocks
-RUN luarocks install lua-resty-openidc
-
-# Install OpenResty
-RUN yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-RUN yum install -y openresty openresty-resty
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin/:/usr/local/openresty/nginx/sbin/:/usr/local/openresty/bin/
-
-# Credstash
-RUN yum install -y python-pip &&  pip install credstash
-
-# Clean
-RUN yum groupremove -y 'Development Tools' && yum clean -y all
 
 # Logs and setup
 USER root
-RUN  ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
-	&& ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log
+RUN ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log && \
+	ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log && \
+	ln -sf /usr/local/openresty/nginx/logs/access.log /var/log/access.log && \
+	ln -sf /usr/local/openresty/nginx/logs/error.log /var/log/error.log
 COPY etc/conf.d /usr/local/openresty/nginx/conf/conf.d/
 COPY etc/nginx.conf /usr/local/openresty/nginx/conf/
 
 # Ports and Docker stuff
 EXPOSE 80
 STOPSIGNAL SIGTERM
-ENTRYPOINT ["/usr/bin/openresty", "-g", "daemon off;"]
+ENTRYPOINT ["/usr/local/openresty/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
-IMAGE_NAME	:= "mozilla.oidc.accessproxy"
-PORTS		:= "8080:80"
-HUB_URL		:= "656532927350.dkr.ecr.us-west-2.amazonaws.com"
-COMPOSE_CMD	:= "up"
+IMAGE_NAME		:= "mozilla.oidc.accessproxy"
+PORTS			:= "-p 80:80 -p 443:443"
+HUB_URL			:= "656532927350.dkr.ecr.us-west-2.amazonaws.com"
+COMPOSE_CMD		:= "up"
+discovery_url	:=
+backend     	:= "http://localhost:5000"
+client_id   	:=
+client_secret	:=
+httpsredir		:= "yes"
+sessionsecret	:=
+cookiename		:= "session"
+allowed_group	:=
 
 all: help
 
@@ -19,7 +27,7 @@ compose: compose/docker-compose.base.yml
 
 compose-detach: compose/docker-compose.base.yml
 	touch compose/local.env
-	docker-compose -f compose/docker-compose.base.yml -f compose/docker-compose.rebuild.yml -f compose/docker-compose.dev.yml $(COMPOSE_CMD) -d
+	docker-compose -f compose/docker-compose.base.yml -f compose/docker-compose.rebuild.yml -f compose/docker-compose.dev.yml $(COMPOSE_CMD) --detach
 
 compose-staging: compose/docker-compose.base.yml
 	touch compose/local.env
@@ -30,7 +38,17 @@ compose-production: compose/docker-compose.base.yml
 	docker-compose -f compose/docker-compose.base.yml -f compose/docker-compose.norebuild.yml -f compose/docker-compose.prod.yml $(COMPOSE_CMD)
 
 run: Dockerfile
-	docker run -i -p $(PORTS)  -t $(IMAGE_NAME)
+	docker run -i \
+	  $(PORTS) \
+	  -e discovery_url \
+	  -e backend \
+	  -e client_id \
+	  -e client_secret \
+	  -e httpsredir \
+	  -e sessionsecret \
+	  -e cookiename \
+	  -e allowed_group \
+	  -t $(IMAGE_NAME)
 
 hublogin: Dockerfile build tag
 	docker login

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ For testing, or if credstash isn't being used, you can also pass secrets through
 - `client_secret`: This is your shared OIDC secret.
 - `backend`: This is the service to proxy.
 - `allowed_group`: If set, only allow users in this group to log in.
-- `redirect_uri_path`: This is where the OIDC provider will redirect to after authentication.  
 - `httpsredir`: If set to `yes` then http will redirect automatically to https, otherwise it won't. (default: `yes`).
 - `cookiename`: Sets the cookie/session name. Useful if you run multiple proxies with the same domain but different
   ports

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Wow that's a lot of words. What this is a reverse proxy that stands in front of 
 no exception.
 While doing so it can either pass ("whitelist") or require authentication, from an OIDC (OpenID Connect) provider.
 
-This proxy use the OpenResty version of Nginx, that has Lua support, and uses the [`lua-resty-openidc`](https://github.com/zmartzone/lua-resty-openidc) library for
+This proxy uses the OpenResty version of Nginx, that has Lua support, and uses the [`lua-resty-openidc`](https://github.com/zmartzone/lua-resty-openidc) library for
 authentication, as well as [`credstash`](https://github.com/fugue/credstash) to fetch credentials as needed.
 
 ## Setup
-- Edit etc/conf.d/server.lua to your liking (in particular `app_name` and maybe `opts`)
+- Edit `etc/conf.d/server.lua` to your liking (in particular `app_name` and maybe `opts`)
 - Ensure you have the same secrets configured in credstash on your AWS instance, if you plan to use that
 
-For testing, or if not using credstash you can also pass secret through environment variables:
+For testing, or if credstash isn't being used, you can also pass secrets through environment variables:
 
 - `discovery_url`: This is the well-known URL for your OIDC provider, such as
   `https://auth.mozilla.auth0.com/.well-known/openid-configuration`
@@ -27,7 +27,8 @@ For testing, or if not using credstash you can also pass secret through environm
 You can manually start this as such, if you like:
 
 ```
-$ docker run -p 8080:80 -e discovery_url=localhost -e backend=http://localhost:5000 -e client_id=1 -e client_secret=1 -ti mozilla.oidc.accessproxy:latest
+$ make build
+$ make run
 ```
 
 ### AWS Deployment
@@ -44,3 +45,13 @@ By default the Access Proxy does NOT configure TLS (HTTPS). This is up to you to
 supports TLS, or to configure TLS. It is **very, very strongly** discouraged to run this access proxy without TLS. In
 other words, do not do that, it's a terrible idea and will lead to compromise of your service.
 If you need a certificate get it from LetsEncrypt for free.
+
+## Config Structure
+
+* `nginx.conf`
+  * `conf.d/nginx_lua.conf`
+  * `conf.d/headers.conf`
+  * `conf.d/server.conf`
+    * `conf.d/proxy_auth_bypass.conf` : optional
+    * `conf.d/server.lua` : set the `opts` settings
+    * `conf.d/openidc_layer.lua` : use `resty.openidc` to do OIDC auth

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For testing, or if credstash isn't being used, you can also pass secrets through
 - `backend`: This is the service to proxy.
 - `allowed_group`: If set, only allow users in this group to log in.
 - `redirect_uri_path`: This is where the OIDC provider will redirect to after authentication.  
-- `httpsredir`: If set to `no` then http will not redirect automatically to https.
+- `httpsredir`: If set to `yes` then http will redirect automatically to https, otherwise it won't. (default: `yes`).
 - `cookiename`: Sets the cookie/session name. Useful if you run multiple proxies with the same domain but different
   ports
 - `sessionsecret`: Sets a session secret.

--- a/etc/conf.d/openidc_layer.lua
+++ b/etc/conf.d/openidc_layer.lua
@@ -1,5 +1,5 @@
 -- Lua reference for nginx: https://github.com/openresty/lua-nginx-module
--- Lua reference for openidc: https://github.com/pingidentity/lua-resty-openidc
+-- Lua reference for openidc: https://github.com/zmartzone/lua-resty-openidc
 local oidc = require("resty.openidc")
 local cjson = require( "cjson" )
 

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -52,3 +52,57 @@ server {
     proxy_pass $backend;
   }
 }
+
+
+server {
+  listen       443;
+
+  ssl on;
+  server_name localhost;
+  ssl_certificate /usr/local/openresty/nginx/conf/ssl/localhost.crt;
+  ssl_certificate_key /usr/local/openresty/nginx/conf/ssl/localhost.key;
+
+  root         /dev/null;
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root       /usr/local/openresty/nginx/html/;
+  }
+  # LUA / Access Proxy settings
+  set_by_lua_block $backend { return os.getenv("backend") }
+  set_by_lua_block $cookiename { return os.getenv("cookiename") }
+  set_by_lua_block $sessionsecret { return os.getenv("sessionsecret") }
+
+  set $session.check.ua off;
+  set $session_storage shm;
+  set $session_cookie_persistent on;
+  set $session_cookie_path "/";
+  set $session_check_ssi off;
+  set $session_secret $sessionsecret;
+  set $session_cookie_samesite off;
+  # Default session to 7 days (604800s), if used with refresh_session_interval or access_token_expires_in
+  # Then session can be rather long (usually 7 to 30 days) since the session will be invalidated when the
+  # user is no longer valid regardless of the cookie's actual expiration.
+  set $session_cookie_lifetime 604800;
+  set $session_name $cookiename;
+
+  # Bypass authentication for certain locations (DANGEROUS!)
+  # include conf.d/proxy_auth_bypass.conf;
+
+  location = /health {
+    return 200;
+    access_log off;
+  }
+
+  # Default location, will enforce authentication there
+  location / {
+
+    proxy_set_header "X-Forwarded-Proto" "https";
+    proxy_set_header "X-Forwarded-Port" "443";
+    proxy_set_header "X-Forwarded-For" $proxy_add_x_forwarded_for;
+    proxy_set_header "X-Real-IP" $remote_addr;
+    proxy_set_header "Host" $host;
+    access_by_lua_file "/usr/local/openresty/nginx/conf/conf.d/openidc_layer.lua";
+    proxy_pass $backend;
+  }
+}
+

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -10,7 +10,8 @@ server {
   }
   # LUA / Access Proxy settings
   set_by_lua_block $backend { return os.getenv("backend") }
-  set_by_lua_block $httpsredir { if (os.getenv("httpsredir") ~= 'no') and (ngx.var.http_x_forwarded_proto ~= 'https') then return "yes" else return "no" end}
+  # If the user connected over http and $httpsredir is either unset or set to yes, then return a redirect to https
+  set_by_lua_block $rewrite_http_to_https { if ((os.getenv("httpsredir") == 'yes') or (os.getenv("httpsredir") == nil)) and (ngx.var.http_x_forwarded_proto == 'http') then return "yes" else return "no" end }
   set_by_lua_block $cookiename { return os.getenv("cookiename") }
   set_by_lua_block $sessionsecret { return os.getenv("sessionsecret") }
 
@@ -38,7 +39,7 @@ server {
   # Default location, will enforce authentication there
   location / {
     # Ensure we get traffic from an ELB that listens over HTTPS
-    if ($httpsredir != 'no') {
+    if ($rewrite_http_to_https = yes) {
       rewrite ^ https://$host$request_uri? permanent;
     }
 

--- a/etc/conf.d/server.lua
+++ b/etc/conf.d/server.lua
@@ -52,9 +52,9 @@ opts = {
   -- If using renew_access_token_on_expiry you may need a specific scope to request a refresh token
   --scope = "openid email profile offline_access",
   scope = "openid email profile",
-  refresh_session_interval = 900
   --proxy_opts = {
   -- http_proxy  = "http://insert_proxy_hostname:3128",
   -- https_proxy = "http://insert_proxy_hostname:3128"
-  --}
+  --},
+  refresh_session_interval = 900
 }

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -1,9 +1,10 @@
 # WARNING:
-# This is an example configuration. You may want to check and only integrate necessary parts to
-# fit your particular setup.
-# Most interesting settings are under conf.d/* and not in this configuration file. You might still need to look here to
-# get a basic OpenResty (Nginx+Lua) setup running.
-#
+# This is an example configuration. You may want to check and only integrate
+# necessary parts to fit your particular setup.
+# Most interesting settings are under conf.d/* and not in this configuration
+# file. You might still need to look here to get a basic OpenResty (Nginx+Lua)
+# setup running.
+
 worker_processes  1;
 env discovery_url;
 env client_id;


### PR DESCRIPTION
*  Move proxy_opts so that uncommenting it results in valid syntax 
* Fix grammar and typos in README 
* Clarify logic around httpsredir so it's easier to understand
* Add HTTPS listener 
* Surface environment variables into the docker container for the make run target
* Change port publishing from 8080 to 80
* Add port publishing for port 443
* Remove redirect_uri_path from README as it's not an environment variable controlled setting (Fixes #18)
* Reduce docker image size and improve image
    * Pin yum signing keys
    * Stop installing package documentation
    * Remove development tools after their installed to save space
    * Create a self signed cert for https
    * Remove openssl lua devel packages as they don't appear to be needed
    * Remove yum-utils as it doesn't appear to be needed
    * Add symlinks for logs to /var/logs/
    * Change ENTRYPOINT to actual binary not symlink for clarity
